### PR TITLE
efl: short-circuit test if wl_display connection fails

### DIFF
--- a/src/test/efl/elmtestharness.cpp
+++ b/src/test/efl/elmtestharness.cpp
@@ -49,6 +49,10 @@ const test::Client& ElmTestHarness::client() const
 
 void ElmTestHarness::run()
 {
+	ecore_wl_init(NULL);
+
+	ASSERT(NULL != ecore_wl_display_get());
+
 	setup();
 
 	ecore_idler_add(idleStep, this);
@@ -56,6 +60,8 @@ void ElmTestHarness::run()
 	elm_run();
 
 	teardown();
+
+	ecore_wl_shutdown();
 
 	ASSERT(not haveStep());
 }
@@ -183,7 +189,6 @@ public:
 
 	void setup()
 	{
-		ecore_wl_init(NULL);
 		queueStep(boost::bind(&PointerInterfaceTest::test, boost::ref(*this)));
 	}
 


### PR DESCRIPTION
Force the test to abort early if ecore_wl_init fails to make
a connection to the wl_display.  For example, if a test causes
the compositor to crash, then this short-circuit prevents other
tests from continuing and potentially getting stuck waiting for
a test timeout to occur.

Signed-off-by: U. Artie Eoff ullysses.a.eoff@intel.com
