### PR TITLE
gtk: fix vtable for GtkTestHarness

### DIFF
--- a/src/test/gtk+/testharness.cpp
+++ b/src/test/gtk+/testharness.cpp
@@ -62,7 +62,7 @@ const test::Client& GtkTestHarness::client() const
 	return c;
 }
 
-void GtkTestHarness::yield(const unsigned time) const
+void GtkTestHarness::yield(const unsigned time, bool strict) const
 {
 	gtk_main_iteration_do(gtk_false());
 	usleep(time);

--- a/src/test/gtk+/testharness.h
+++ b/src/test/gtk+/testharness.h
@@ -40,7 +40,9 @@ public:
 
 	void run();
 
-	/*virtual*/ void yield(const unsigned time = 0.01 * 1e6) const;
+	/*virtual*/ void yield(const unsigned time = 0.01 * 1e6,
+			       bool strict = false) const;
+
 	/*virtual*/ const Client& client() const;
 
 private:

--- a/src/test/harness.h
+++ b/src/test/harness.h
@@ -48,7 +48,9 @@ public:
 
 	virtual const Client& client() const = 0;
 
-	void		yield(const unsigned time = 0.001 * 1e6, bool strict = false) const;
+	virtual void yield(const unsigned time = 0.001 * 1e6,
+			   bool strict = false) const;
+
 	void		synchronized(std::function<void()>) const;
 
 	void		runNextStep();


### PR DESCRIPTION
yield method for GtkTestHarness was declared and defined with
different prototype as in parent class. Thus it did not
override the element in vtable and gtk+ tests called
only usleep() instead of doing gtk loop iteration.

fixes #8

Signed-off-by: Marek Chalupa <mchqwerty@gmail.com>