### PR TITLE
gtk: fix fullscreen test

### DIFF
--- a/src/test/gtk+/test_window_fullscreen.cpp
+++ b/src/test/gtk+/test_window_fullscreen.cpp
@@ -97,9 +97,7 @@ public:
 		YIELD_UNTIL(isConfigured_);
 
 		std::cout << "...checking client size == fullscreen size" << std::endl;
-		gtk_window_get_size(*this, &width, &height);
-		FAIL_UNLESS_EQUAL(width, fullscreen.width);
-		FAIL_UNLESS_EQUAL(height, fullscreen.height);
+		YIELD_UNTIL(clientHasSize(fullscreen.width, fullscreen.height));
 
 		std::cout << "...checking server geometry == fullscreen geometry" << std::endl;
 		YIELD_UNTIL(isServerGeometry(fullscreen));
@@ -117,11 +115,21 @@ public:
 		gtk_window_get_size(*this, &width, &height);
 
 		std::cout << "...checking client size == initial size" << std::endl;
-		FAIL_UNLESS_EQUAL(width, initial.width);
-		FAIL_UNLESS_EQUAL(height, initial.height);
+		YIELD_UNTIL(clientHasSize(initial.width, initial.height));
 
 		std::cout << "...checking server geometry == initial geometry" << std::endl;
 		YIELD_UNTIL(isServerGeometry(initial));
+	}
+
+	bool clientHasSize(int width, int height)
+	{
+		int w, h;
+		gtk_window_get_size(*this, &w, &h);
+
+		if (w == width && h == height)
+			return true;
+
+		return false;
 	}
 
 	bool isServerGeometry(const Geometry what)


### PR DESCRIPTION
We assumed that the surface is fullscreened right away we send
fullscreen request. This may not be true, since events go like this:

    client              server
-----------------------------------
 -> fullscreen
                     <- configure
 -> set_geometry
 -> < draw, commit >

We checked for client's size after set_geometry but before
drawing and commiting, so the size was not right yet. Also
fullscreening may have an animation, so the client can have
some intermediate sizes before it is resized over whole screen.
The same when unfullscreening back to initial size.

Fix it by waiting until the client has the fullscreen (initial) size.
(If it won't, the test will time-out)

Signed-off-by: Marek Chalupa <mchqwerty@gmail.com>