### PR TITLE
build: Support out-of-tree compilation

### DIFF
--- a/src/extensions/weston/Makefile.am
+++ b/src/extensions/weston/Makefile.am
@@ -15,7 +15,7 @@ weston_wfits_la_SOURCES =		\
 	input-emulator.cpp		\
 	input-emulator-uinput.cpp	\
 	input-emulator-notify.cpp	\
-	$(top_srcdir)/src/extensions/protocol/wayland-fits-protocol.c
+	$(top_builddir)/src/extensions/protocol/wayland-fits-protocol.c
 
 weston_wfits_la_LDFLAGS =		\
 	-module -avoid-version
@@ -27,6 +27,7 @@ weston_wfits_la_LIBADD =		\
 
 weston_wfits_la_CPPFLAGS =		\
 	-I$(top_srcdir)/src		\
+	-I$(top_builddir)/src		\
 	$(GCC_CFLAGS)			\
 	$(WAYLAND_SERVER_CFLAGS)	\
 	$(WESTON_CFLAGS)		\

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -9,7 +9,7 @@ wfits_SOURCES =				\
 	harness.cpp			\
 	client.cpp			\
 	testmain.cpp			\
-	$(top_srcdir)/src/extensions/protocol/wayland-fits-protocol.c
+	$(top_builddir)/src/extensions/protocol/wayland-fits-protocol.c
 
 wfits_LDADD =				\
 	core/libwfits-core.la		\
@@ -23,6 +23,7 @@ wfits_LDFLAGS =				\
 
 wfits_CPPFLAGS =			\
 	-I$(top_srcdir)/src		\
+	-I$(top_builddir)/src		\
 	$(CHECK_CFLAGS)			\
 	$(XKBCOMMON_CFLAGS)		\
 	$(WAYLAND_CFLAGS)		\

--- a/src/test/core/Makefile.am
+++ b/src/test/core/Makefile.am
@@ -31,6 +31,7 @@ libwfits_core_la_LIBADD =		\
 
 libwfits_core_la_CPPFLAGS =		\
 	-I$(top_srcdir)/src		\
+	-I$(top_builddir)/src		\
 	$(WAYLAND_CFLAGS)		\
 	$(XKBCOMMON_CFLAGS)		\
 	$(CHECK_CFLAGS)

--- a/src/test/efl/Makefile.am
+++ b/src/test/efl/Makefile.am
@@ -53,6 +53,7 @@ libwfits_efl_la_LIBADD =		\
 
 libwfits_efl_la_CPPFLAGS =		\
 	-I$(top_srcdir)/src		\
+	-I$(top_builddir)/src		\
 	-DMEDIA_PATH=$(MEDIA)		\
 	$(XKBCOMMON_CFLAGS)		\
 	$(WAYLAND_CFLAGS)		\

--- a/src/test/gtk+/Makefile.am
+++ b/src/test/gtk+/Makefile.am
@@ -16,6 +16,7 @@ libwfits_gtk_la_LIBADD =		\
 
 libwfits_gtk_la_CPPFLAGS =		\
 	-I$(top_srcdir)/src		\
+	-I$(top_builddir)/src		\
 	$(WAYLAND_CFLAGS)		\
 	$(XKBCOMMON_CFLAGS)		\
 	$(GTK_CFLAGS)			\


### PR DESCRIPTION
Some build systems, such as Yocto, use a separate directory
to output compilation results.

As we are creating some source and headers files with the
help of "wayland-scanner", those files will end up in this
dedicated build directory ; in order for the process to
succeed, it is thus needed that the Makefiles reference it.

Signed-off-by: Manuel Bachmann <manuel.bachmann@iot.bzh>