### PR TITLE
build: Support building with Weston >= 1.8.91

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -40,6 +40,12 @@ boost::lambda::placeholder3_type _3_;
 #define foreach BOOST_FOREACH
 #define foreach_reverse BOOST_REVERSE_FOREACH
 
+#ifndef container_of
+#define container_of(ptr, type, member) ({                              \
+        const __typeof__( ((type *)0)->member ) *__mptr = (ptr);        \
+        (type *)( (char *)__mptr - offsetof(type,member) );})
+#endif
+
 struct Geometry
 {
 	Geometry(

--- a/src/extensions/weston/weston-wfits.cpp
+++ b/src/extensions/weston/weston-wfits.cpp
@@ -94,9 +94,15 @@ struct weston_seat * Globals::seat()
 void Globals::pointerXY(wl_fixed_t *x, wl_fixed_t *y)
 {
 	struct weston_seat *seat(Globals::seat());
+#if WESTON_SDK_AT_LEAST(1, 8, 91)
+	struct weston_pointer *pointer = weston_seat_get_pointer(seat);
 
+	*x = pointer->x;
+	*y = pointer->y;
+#else
 	*x = seat->pointer->x;
 	*y = seat->pointer->y;
+#endif
 }
 
 bool Globals::isHeadless()


### PR DESCRIPTION
In recent versions of Weston, the "container_of" macro  is
not exposed via a public header anymore. Just redefine it
locally if needed; it keeps the code readable and will
always work.

Since Weston 1.8.91 (well more precisely, somewhere in the
middle of 1.8.90 but we have no way to test that) member
elements of "weston_seat" (such as "weston_pointer",
"weston_touch"...) can not be accessed directly anymore,
but require a dedicated function. Since it is only
required in one place and wayland-fits is all about testing
various versions of Wayland/Weston, let us have a #ifdef
until such breakages begin to happen everywhere.

Change-Id: If3bf867133c86ac43c5e5d7031cb467d5109c7b9
Signed-off-by: Manuel Bachmann manuel.bachmann@iot.bzh
